### PR TITLE
Override other commands

### DIFF
--- a/src/com/superiornetworks/icarus/IcarusMod.java
+++ b/src/com/superiornetworks/icarus/IcarusMod.java
@@ -71,7 +71,7 @@ public class IcarusMod extends AeroPlugin<IcarusMod>
         handler = new SimpleCommandHandler(plugin);
         handler.setCommandClassPrefix("Command_");
         handler.loadFrom(Command_say.class.getPackage());
-        handler.registerAll();
+        handler.registerAll(fallbackPrefix, true);
 
         // More YAML Setting Up and information.
         icmconfig = new ICM_Config(plugin, "config.yml");

--- a/src/com/superiornetworks/icarus/IcarusMod.java
+++ b/src/com/superiornetworks/icarus/IcarusMod.java
@@ -71,7 +71,7 @@ public class IcarusMod extends AeroPlugin<IcarusMod>
         handler = new SimpleCommandHandler(plugin);
         handler.setCommandClassPrefix("Command_");
         handler.loadFrom(Command_say.class.getPackage());
-        handler.registerAll(fallbackPrefix, true);
+        handler.registerAll(handler.getCommandClassPrefix(), true);
 
         // More YAML Setting Up and information.
         icmconfig = new ICM_Config(plugin, "config.yml");


### PR DESCRIPTION
In order to register commands that already exist (i.e. essentials ban and our ban), you need to use the force register in this method.

If you don't use this, commands that already exist won't register and loading the plugin before everything else doesn't change that.
